### PR TITLE
chore: change param databases_path from &str to PathBuf

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 pub fn conductor_config(
     admin_port: u16,
-    databases_path: &str,
+    databases_path: PathBuf,
     lair_path: &Option<PathBuf>,
     webrtc_signal_url: &str,
     bootstrap_url: &Url2,
@@ -19,7 +19,7 @@ pub fn conductor_config(
         signal_url: webrtc_signal_url.to_owned(),
     });
     ConductorConfig {
-        environment_path: PathBuf::from(databases_path).into(),
+        environment_path: databases_path.into(),
         dpki: None,
         db_sync_strategy: DbSyncStrategy::default(),
         keystore: KeystoreConfig::LairServerInProc {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ ending in .happ")]
 will be overridden if an existing
 configuration is found at this path"
     )]
-    datastore_path: String,
+    datastore_path: PathBuf,
 
     #[structopt(long, default_value = "main-app")]
     app_id: String,


### PR DESCRIPTION
Makes the param 'databases_path' a PathBuf instead of a &str