### PR TITLE
updated proxy url to the same as launcher uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ OPTIONS:
                                            do not pass a value here, it will use a default which is equal to the
                                            value of `<datastore_path>/keystore`.
         --network-seed <network-seed>
-        --proxy-url <proxy-url>             [default: kitsune-proxy://SYVd4CF3BdJ4DS7KwLLgeU3_DbHoZ34Y-
-                                           qroZ79DOs8/kitsune-quic/h/165.22.32.11/p/5779/--]
+        --proxy-url <proxy-url>             [default: kitsune-proxy://f3gH2VMkJ4qvZJOXx0ccL_Zo5n-s_CnBjSzAsEHHDCA/kitsune-quic/h/137.184.142.208/p/5788/--]
 
 ARGS:
     <happ-path>         the path to a HAPP file to be

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ value of `<datastore_path>/keystore`."
     #[structopt(
         long,
         parse(from_str = Url2::parse),
-        default_value = "kitsune-proxy://SYVd4CF3BdJ4DS7KwLLgeU3_DbHoZ34Y-qroZ79DOs8/kitsune-quic/h/165.22.32.11/p/5779/--",
+        default_value = "kitsune-proxy://f3gH2VMkJ4qvZJOXx0ccL_Zo5n-s_CnBjSzAsEHHDCA/kitsune-quic/h/137.184.142.208/p/5788/--",
         help = ""
     )]
     proxy_url: Url2,


### PR DESCRIPTION
Apparently, `proxy.holochain.org`, which is the one that the electron-runner has been using so far has been recently decomissioned. This PR changes to using the same proxy that the launcher uses and is still running.

cc @mattyg since I know that you've been using holochain-runner recently